### PR TITLE
0.0.2 (quick fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.0.2] - 2025-07-04
+
+### Fixed
+- Fixed 404 Not Found error when sending POST requests to the model_server API via httpx, caused by missing or incorrect Content-Type header.
 
 ## [0.0.1] - 2025-06-17
 

--- a/GenAIServices/ollama.py
+++ b/GenAIServices/ollama.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Generator
+from collections.abc import Generator
 
 import httpx
 
@@ -58,10 +58,14 @@ class OllamaHandler(GenAIOperator):
             json.JSONDecodeError: If the response cannot be decoded as JSON.
             BaseException: For any other exceptions that occur during the request.
         """
-
+        headers = {"Content-Type": "application/json"}
         try:
             with httpx.stream(
-                "POST", url=self.url + "api/chat", json=request_data, timeout=None
+                "POST",
+                url=self.url + "api/chat",
+                json=request_data,
+                headers=headers,
+                timeout=None,
             ) as response:
                 response.encoding = "utf-8"
                 if response.status_code != 200:


### PR DESCRIPTION
Fixed 404 Not Found error when sending POST requests to the model_server API via httpx, caused by missing or incorrect Content-Type header.